### PR TITLE
Pad image file name with zeroes

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -335,11 +335,14 @@ def mapExtractedImages(dirs, isPdf, main_dir):
         counter = 0
         currentDir = path.join(main_dir, EXTRACT_DIR, dir)
         # Move images to ZIP_DIR, renaming them to be continuous
-        for img in natsorted(os.listdir(currentDir)):
+        imglist = natsorted(os.listdir(currentDir))
+        imglistlength = len(imglist)
+        imglistlengthmax = len(str(imglistlength)) + 1
+        for img in imglist:
 
             origin = path.join(currentDir, img)
             destination = path.join(main_dir, ZIP_DIR, dir)
-            n = str(counter)
+            n = str(counter).zfill(imglistlengthmax)
 
 
             f(origin, destination, n)


### PR DESCRIPTION
Pad the file name of extracted images, so that readers that use alphabetical sorting still show images in the correct order. 

I used your tool to combine some cbz files into one to put on my Kobo device, and it was showing some out of order because it went image 19,2,20,...29,3,30,...39,4,40... etc.

The code gets the files in the current directory - _imglist_; gets the total number of files - _imglistlength_, let's say 31 as an example; gets the number of digits in that total plus one, - _imglistlengthmax_, i.e. 31 -> "31" -> 2 digits -> 2+1 = 3; then later uses zfill to pad the image number, i.e pads 31 to 031, 3 to 003. 

It probably doesn't need the +1, actually, but it doesn't hurt I guess.